### PR TITLE
Add basic auth to local server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ CARDDAV_URL=https://contacts.zoho.com/dav/you@example.com/contacts/
 USERNAME=you@example.com
 PASSWORD=your_password
 
+# Credentials for protecting the local server
+LOCAL_USERNAME=admin
+LOCAL_PASSWORD=change_me
+
 # Directory to store cached vCard files
 CACHE_DIR=cache
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Use your Zoho credentials for authentication.
 
 A small Python server is provided in `local_carddav_server.py` to cache your Zoho
 contacts and expose them locally. Configure it with a `.env` file based on
-`.env.example`:
+`.env.example`.  You can also set `LOCAL_USERNAME` and `LOCAL_PASSWORD` to
+require Basic Auth when accessing the proxy:
 
 ```bash
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- enable username/password auth for the Python proxy server
- document local auth environment variables
- update `.env.example`

## Testing
- `python -m py_compile local_carddav_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686b21358e9c832983025b8c856df9cc