### PR TITLE
Fix namespaced tags for CardDAV

### DIFF
--- a/local_carddav_server.py
+++ b/local_carddav_server.py
@@ -81,7 +81,7 @@ def sync_remote():
             logger.warning("PROPFIND failed with status %s", res.status_code)
             return
 
-        hrefs = re.findall(r"<href>([^<]+\.vcf)</href>", res.text)
+        hrefs = re.findall(r"<(?:\w+:)?href>([^<]+\.vcf)</(?:\w+:)?href>", res.text)
         count = 0
         for href in hrefs:
             url = urljoin(CARDDAV_URL, href)


### PR DESCRIPTION
## Summary
- support Baïkal's namespaced `<d:href>` tags in the demo server and plugin
- update build output

## Testing
- `npm run build`
- `python -m py_compile local_carddav_server.py`


------
https://chatgpt.com/codex/tasks/task_e_686b36ce6cf083298ab7b5cd6f5e26eb