### PR TITLE
Enhance contact sync utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contact Link synchronizes your Obsidian vault with a CardDAV server so your note
 - Import contacts from a CSV file (`contacts.csv`).
 - Dashboard table with phone and email actions and mention counts.
 - Birthday calendar exported as an ICS file.
-- Commands to insert contact links in any note.
+- Commands to insert contact links in any note, link the current note to a contact, and create a contact from the active page.
 - Works on both desktop and mobile without extra dependencies.
 
 This project still provides only a lightweight example implementation but now demonstrates how a more complete contact manager could be built.


### PR DESCRIPTION
## Summary
- hide the sync counter once processing ends
- show notices whenever contacts are updated
- include all notes with a `uid` frontmatter when syncing
- add commands to link the current note to a contact or create a contact from the active page
- document the new commands in the README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686be2bae9108329931d788196182a19