### PR TITLE
Add advanced contacts dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Contact Link synchronizes your Obsidian vault with a CardDAV server so your note
 - Customisable frontmatter mapping for contact fields.
 - Relationship field to track how contacts are related.
 - Import contacts from a CSV file (`contacts.csv`).
-- Dashboard table with phone and email actions and mention counts.
-- Styled dashboard table for better readability.
+- Dashboard with responsive contact cards, quick actions, mention counts, search and filters.
+- Dashboard metrics summarizing totals and upcoming birthdays.
 - Birthday calendar exported as an ICS file.
 - Commands to insert contact links in any note, link the current note to a contact, and create a contact from the active page.
 - Works on both desktop and mobile without extra dependencies.

--- a/styles.css
+++ b/styles.css
@@ -42,3 +42,51 @@ If your plugin does not need CSS, delete this file.
 .cl-dashboard tr:nth-child(even) {
     background-color: var(--background-secondary);
 }
+
+.cl-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.cl-card {
+    border: 1px solid var(--background-modifier-border);
+    padding: 8px;
+    border-radius: 4px;
+    background-color: var(--background-primary);
+}
+
+.cl-card-actions {
+    margin-top: 4px;
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.cl-metrics {
+    margin-bottom: 8px;
+    font-weight: bold;
+    display: flex;
+    gap: 12px;
+}
+
+@media (max-width: 600px) {
+    .cl-card-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.cl-cal-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 4px;
+    margin-top: 8px;
+}
+
+.cl-cal-day {
+    border: 1px solid var(--background-modifier-border);
+    min-height: 40px;
+    padding: 2px;
+    font-size: 0.8em;
+}


### PR DESCRIPTION
## Summary
- revamp dashboard to use a modal with responsive contact cards
- show metrics, search and filtering in the dashboard
- include upcoming birthday calendar modal
- add responsive card and calendar styles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c0e2c26a88329a9ef7d6255d2aff1