### PR TITLE
Add dashboard ribbon icon and improve card text wrapping

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -127,6 +127,8 @@ export default class ContactLinkPlugin extends Plugin {
 
         this.registerView(VIEW_TYPE_DASHBOARD, (leaf) => new DashboardView(leaf, this));
 
+        this.addRibbonIcon('layout-dashboard', 'Open contacts dashboard', () => this.openDashboard());
+
         this.addCommand({
             id: 'sync-contacts',
             name: 'Sync contacts with CardDAV',

--- a/styles.css
+++ b/styles.css
@@ -59,12 +59,18 @@ If your plugin does not need CSS, delete this file.
     display: flex;
     flex-direction: column;
     gap: 4px;
+    overflow-wrap: anywhere;
+}
+
+.cl-card * {
+    overflow-wrap: anywhere;
 }
 
 .cl-card-header {
     font-weight: 600;
     margin-bottom: 2px;
     font-size: 1.1em;
+    word-break: break-word;
 }
 
 .cl-card-info {
@@ -80,6 +86,7 @@ If your plugin does not need CSS, delete this file.
     display: flex;
     align-items: center;
     gap: 6px;
+    word-break: break-word;
 }
 
 .cl-card-info li a {


### PR DESCRIPTION
## Summary
- add a ribbon icon to quickly open the contacts dashboard
- wrap overflowing dashboard text so it stays within cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686f698767b08329b32067d1ccda9ba1