### PR TITLE
Add Fruux discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ https://contacts.zoho.com/dav/<your-email>/contacts/
 
 Use your Zoho credentials for authentication.
 
+### Fruux CardDAV Setup
+
+Set the CardDAV URL to:
+
+```
+https://dav.fruux.com
+```
+
+The plugin will automatically discover your address books via the `/.well-known/carddav` endpoint. Choose the correct collection from the dropdown once the books are listed.
+
 
 ## Getting Started
 

--- a/main.ts
+++ b/main.ts
@@ -418,7 +418,11 @@ export default class ContactLinkPlugin extends Plugin {
             return new DOMParser().parseFromString(res.text, 'application/xml');
         };
         try {
-            const base = this.settings.carddavUrl.replace(/\/$/, '');
+            let base = this.settings.carddavUrl.replace(/\/$/, '');
+            const parsed = new URL(base);
+            if (parsed.pathname === '' || parsed.pathname === '/') {
+                base = base.replace(/\/$/, '') + '/.well-known/carddav';
+            }
             // current-user-principal discovery
             let doc = await propfind(base, '0', '<?xml version="1.0"?><propfind xmlns="DAV:"><prop><current-user-principal/></prop></propfind>');
             const principalHref = doc.getElementsByTagNameNS('DAV:', 'href')[0]?.textContent;


### PR DESCRIPTION
## Summary
- improve discovery when CardDAV URL is the server root by using `/.well-known/carddav`
- document Fruux setup instructions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875dc0079ac832994d1c7e15a60eabb