### PR TITLE
Fix tag graph view initialization container

### DIFF
--- a/taglink-graph/main.ts
+++ b/taglink-graph/main.ts
@@ -1,4 +1,5 @@
 // main.ts
+// Modified by ChatGPT Codex 2025-05-14
 import { Plugin, TFile, ItemView, WorkspaceLeaf, Notice } from 'obsidian';
 
 interface TagLinkData {
@@ -48,7 +49,7 @@ class TagLinkGraphView extends ItemView {
     }
 
     async onOpen() {
-        const container = this.containerEl.children[1];
+        const container = this.contentEl;
         container.empty();
         container.addClass('tag-link-graph-view');
 


### PR DESCRIPTION
## Summary
- Render the tag graph view using the ItemView content element so the canvas is created in a valid container and the visual graph can display.
- Add attribution comment for recent modifications.

## Testing
- npm install *(fails: npm not available in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693348d1b9b08329af6ee763a9d6f32f)