### PR TITLE
Handle esbuild fallback on no-exec environments

### DIFF
--- a/taglink-graph/package.json
+++ b/taglink-graph/package.json
@@ -22,10 +22,12 @@
     "@typescript-eslint/eslint-plugin": "5.29.0",
     "@typescript-eslint/parser": "5.29.0",
     "builtin-modules": "3.3.0",
-    "esbuild": "0.17.3",
     "esbuild-wasm": "0.17.3",
     "obsidian": "latest",
     "tslib": "2.4.0",
     "typescript": "4.7.4"
+  },
+  "optionalDependencies": {
+    "esbuild": "0.17.3"
   }
 }


### PR DESCRIPTION
## Summary
- allow the esbuild dependency to be optional so installs can proceed even when native binaries cannot run
- dynamically load esbuild and fall back to the WebAssembly build when the native binary is missing or lacks execute permission

## Testing
- not run (npm not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334c7d88948329a7e8a3b24082c833)