### PR TITLE
Fix Tag-Link Graph canvas sizing

### DIFF
--- a/taglink-graph/styles.css
+++ b/taglink-graph/styles.css
@@ -1,0 +1,19 @@
+/* Modified by ChatGPT Codex 2025-05-15 */
+.tag-link-graph-view {
+    height: 100%;
+    width: 100%;
+}
+
+.tag-link-graph-wrapper {
+    position: relative;
+    height: 100%;
+    width: 100%;
+    background: linear-gradient(135deg, #1e1e2e 0%, #0f1020 100%);
+    overflow: hidden;
+}
+
+.tag-link-graph-wrapper canvas {
+    display: block;
+    height: 100%;
+    width: 100%;
+}


### PR DESCRIPTION
## Summary
- ensure the tag-link graph canvas uses a full-height wrapper and scales to device pixel ratio
- stabilize event handlers and cleanup for the graph view resize lifecycle
- add plugin styles so the graph area is visible and fills its pane

## Testing
- Not run (npm is not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933502268c88329ac4b333ef8fb973f)